### PR TITLE
[fix] ReviewControllerTest JwtUtil 의존성 에러 해결

### DIFF
--- a/src/test/java/nbcamp/food_order_platform/review/presentation/controller/ReviewControllerTest.java
+++ b/src/test/java/nbcamp/food_order_platform/review/presentation/controller/ReviewControllerTest.java
@@ -1,6 +1,7 @@
 package nbcamp.food_order_platform.review.presentation.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nbcamp.food_order_platform.global.security.JwtUtil;
 import nbcamp.food_order_platform.review.application.dto.CreateReviewDto;
 import nbcamp.food_order_platform.review.application.service.ReviewService;
 import nbcamp.food_order_platform.review.presentation.dto.request.PostReviewReqDto;
@@ -45,6 +46,9 @@ class ReviewControllerTest {
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMappingContext;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
 
     @Test
     @DisplayName("리뷰 작성 성공 테스트")


### PR DESCRIPTION
## 개요
- 컨트롤러 테스트 내 JwtUtil 의존성 에러 해결
테스트 실행시 @WebMvcTest 테스트 환경에서 JwtAuthenticationFilter가 요구하는 JwtUtil 빈을 @MockitoBean으로 추가하여 테스트 컨텍스트 로딩 실패 문제 해결

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
